### PR TITLE
Fix: TextField Behavior

### DIFF
--- a/Login/Components/PasswordTextField.swift
+++ b/Login/Components/PasswordTextField.swift
@@ -29,7 +29,7 @@ class PasswordTextField: UIView {
         textField.backgroundColor = UIColor(named: "PurplePrimary")
         textField.textColor = .white
         textField.rightViewMode = .always
-        
+        textField.textContentType = .username
         let paddingView = UIView(frame: CGRect(x: 0, y: 0, width: 12, height: textField.frame.height))
         textField.leftView = paddingView
         textField.leftViewMode = .always

--- a/Login/Screens/Login/LoginView.swift
+++ b/Login/Screens/Login/LoginView.swift
@@ -133,12 +133,11 @@ class LoginView: UIView, UITextFieldDelegate {
         }
         
         viewController.viewModel.onLoginSuccess = { [weak self] in
-                self?.emailLabelTextField.text = ""
-                self?.passwordTextField.textField.text = ""
-            }
+            self?.emailLabelTextField.text = ""
+            self?.passwordTextField.textField.text = ""
+        }
         
         viewController.viewModel.signInUser(email: email, password: password)
-        
     }
     
     private func configConstraints(){

--- a/Login/Screens/Login/LoginView.swift
+++ b/Login/Screens/Login/LoginView.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class LoginView: UIView {
+class LoginView: UIView, UITextFieldDelegate {
     private let viewController: LoginViewController
     private let configBackground = ConfigBackground()
     
@@ -40,6 +40,7 @@ class LoginView: UIView {
         textField.backgroundColor = UIColor(named: "PurplePrimary")
         textField.autocapitalizationType = .none
         textField.autocorrectionType = .no
+        textField.delegate = self
         let paddingView = UIView(frame: CGRect(x: 0, y: 0, width: 12, height: textField.frame.height))
         textField.leftView = paddingView
         textField.leftViewMode = .always
@@ -59,6 +60,7 @@ class LoginView: UIView {
     lazy var passwordTextField: PasswordTextField = {
         let passwordField = PasswordTextField()
         passwordField.translatesAutoresizingMaskIntoConstraints = false
+        passwordField.delegate = self
         return passwordField
     }()
     
@@ -90,6 +92,7 @@ class LoginView: UIView {
         configBackGround()
         configHierarchy()
         configConstraints()
+        setupTapGesture()
     }
     
     required init?(coder: NSCoder) {
@@ -170,4 +173,18 @@ class LoginView: UIView {
             signUpButton.heightAnchor.constraint(equalToConstant: 40),
         ])
     }
+    
+    private func setupTapGesture() {
+         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
+         self.addGestureRecognizer(tapGesture)
+     }
+     
+     @objc private func dismissKeyboard() {
+         self.endEditing(true)
+     }
+    
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+          textField.resignFirstResponder()
+          return true
+      }
 }


### PR DESCRIPTION
- Defining the textfield delegate for the LoginView class and assigning the keyboard open and close behaviors
```swift
textField.delegate = self
```

- By assigning the username value to the textContentType property, the field understands that it's not a password and the icloud password saving error doesn't pop up.

   - ERROR: `Cannot show Automatic Strong Passwords for app bundleID: com.example.com due to error: iCloud Keychain is disabled ##`
   - SOLUTION:
      ```swift
       textField.textContentType = .username
      ```